### PR TITLE
Adding CALICO_LIBNETWORK_HOSTNAME env option to change hostname

### DIFF
--- a/driver/ipam_driver.go
+++ b/driver/ipam_driver.go
@@ -14,7 +14,6 @@ import (
 	caliconet "github.com/projectcalico/libcalico-go/lib/net"
 	"github.com/projectcalico/libcalico-go/lib/options"
 	logutils "github.com/projectcalico/libnetwork-plugin/utils/log"
-	osutils "github.com/projectcalico/libnetwork-plugin/utils/os"
 )
 
 type IpamDriver struct {
@@ -142,12 +141,6 @@ func (i IpamDriver) ReleasePool(request *ipam.ReleasePoolRequest) error {
 func (i IpamDriver) RequestAddress(request *ipam.RequestAddressRequest) (*ipam.RequestAddressResponse, error) {
 	logutils.JSONMessage("RequestAddress", request)
 
-	hostname, err := osutils.GetHostname()
-	if err != nil {
-		log.Errorln(err)
-		return nil, err
-	}
-
 	// Calico IPAM does not allow you to choose a gateway.
 	if request.Options["RequestAddressType"] == "com.docker.network.gateway" {
 		err := errors.New("Calico IPAM does not support specifying a gateway.")
@@ -211,7 +204,7 @@ func (i IpamDriver) RequestAddress(request *ipam.RequestAddressRequest) (*ipam.R
 			calicoipam.AutoAssignArgs{
 				Num4:      numIPv4,
 				Num6:      numIPv6,
-				Hostname:  hostname,
+				Hostname:  Hostname,
 				IPv4Pools: poolV4,
 				IPv6Pools: poolV6,
 			},
@@ -231,7 +224,7 @@ func (i IpamDriver) RequestAddress(request *ipam.RequestAddressRequest) (*ipam.R
 		ip := net.ParseIP(request.Address)
 		ipArgs := calicoipam.AssignIPArgs{
 			IP:       caliconet.IP{IP: ip},
-			Hostname: hostname,
+			Hostname: Hostname,
 		}
 		err := i.client.IPAM().AssignIP(context.Background(), ipArgs)
 		if err != nil {

--- a/driver/package.go
+++ b/driver/package.go
@@ -1,8 +1,11 @@
 package driver
 
 import (
+	"fmt"
 	"log"
 	"os"
+
+	osutils "github.com/projectcalico/libnetwork-plugin/utils/os"
 )
 
 const (
@@ -18,10 +21,22 @@ const (
 )
 
 var IFPrefix = "cali"
+var Hostname = ""
 
 func init() {
-	if os.Getenv("CALICO_LIBNETWORK_IFPREFIX") != "" {
-		IFPrefix = os.Getenv("CALICO_LIBNETWORK_IFPREFIX")
-		log.Println("Updated CALICO_LIBNETWORK_IFPREFIX to ", IFPrefix)
+	if value, ok := os.LookupEnv("CALICO_LIBNETWORK_IFPREFIX"); ok {
+		IFPrefix = value
+		log.Println("Updated CALICO_LIBNETWORK_IFPREFIX to ", value)
+	}
+	if value, ok := os.LookupEnv("CALICO_LIBNETWORK_HOSTNAME"); ok {
+		Hostname = value
+		log.Println("Updated CALICO_LIBNETWORK_HOSTNAME to ", value)
+	} else {
+		hostname, err := osutils.GetHostname()
+		if err != nil {
+			panic(fmt.Errorf("Unable to obtain hostname: %s", err.Error()))
+		} else {
+			Hostname = hostname
+		}
 	}
 }


### PR DESCRIPTION
## Description

In case of DC/OS the hostname `felix` is using is not the system's hostname, but the public IP address of the node, as produced by the `get-ip-address` script. This commit disables the default assumption that the hostname is computed by `osutils.GetHostname()` and instead allows it to be overridden by an environment variable.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note