### PR TITLE
Adding support for `org.projectcalico.profile` option

### DIFF
--- a/driver/docker.go
+++ b/driver/docker.go
@@ -1,0 +1,58 @@
+package driver
+
+import (
+	"fmt"
+	"strings"
+)
+
+func parseDockerOptions(dockerOpt map[string]interface{}, optMap *map[string]interface{}) error {
+	var errorMsgs []string
+
+	// This parses both `com.docker.network.generic` options (given as map) and
+	// some of the core docker options, such as `com.docker.network.enable_ipv6`
+	// assuming they are both the same thing
+	for k, v := range dockerOpt {
+
+		// Ensure that key/value format is always in the same format
+		kvOpt := map[string]interface{}{k: v}
+		if k == "com.docker.network.generic" {
+			if v, ok := v.(map[string]interface{}); ok {
+				kvOpt = v
+			} else {
+				errorMsgs = append(errorMsgs,
+					fmt.Sprintf("Docker options error: Expecting `com.docker.network.generic` to be a map"))
+			}
+		}
+
+		// Process remaining options, updating optMap when successful
+		for k, v := range kvOpt {
+			if dv, ok := (*optMap)[k]; ok {
+				switch dv.(type) {
+				case bool:
+					if v, ok := v.(bool); ok {
+						(*optMap)[k] = v
+					} else {
+						errorMsgs = append(errorMsgs, fmt.Sprintf("Expecting option '%s' to be boolean", k))
+					}
+					break
+
+				case string:
+					if v, ok := v.(string); ok {
+						(*optMap)[k] = v
+					} else {
+						errorMsgs = append(errorMsgs, fmt.Sprintf("Expecting option '%s' to be string", k))
+					}
+					break
+				}
+			} else {
+				errorMsgs = append(errorMsgs, fmt.Sprintf("Unknown option '%s'", k))
+			}
+		}
+	}
+
+	if len(errorMsgs) > 0 {
+		return fmt.Errorf(strings.Join(errorMsgs, ", "))
+	}
+
+	return nil
+}

--- a/driver/ipam_driver.go
+++ b/driver/ipam_driver.go
@@ -224,7 +224,6 @@ func (i IpamDriver) RequestAddress(request *ipam.RequestAddressRequest) (*ipam.R
 			IPs = append(IPs, caliconet.IP{ip.IP})
 		}
 
-		// IPs = append(IPsV4Net.IP, IPsV6Net.IP...)
 	} else {
 		// Docker allows the users to specify any address.
 		// We'll return an error if the address isn't in a Calico pool, but we don't care which pool it's in

--- a/driver/network_driver.go
+++ b/driver/network_driver.go
@@ -404,7 +404,7 @@ func (d NetworkDriver) DeleteEndpoint(request *network.DeleteEndpointRequest) er
 
 	if _, err = d.client.WorkloadEndpoints().Delete(
 		context.Background(),
-		d.orchestratorID,
+		d.namespace,
 		wepName,
 		options.DeleteOptions{}); err != nil {
 		err = errors.Wrapf(err, "Endpoint %v removal error", request.EndpointID)
@@ -449,7 +449,7 @@ func (d NetworkDriver) Join(request *network.JoinRequest) (*network.JoinResponse
 		log.Errorln(err)
 		return nil, err
 	}
-	wep, err := weps.Get(ctx, d.orchestratorID, wepName, options.GetOptions{})
+	wep, err := weps.Get(ctx, d.namespace, wepName, options.GetOptions{})
 	if err != nil {
 		log.Errorln(err)
 		return nil, err


### PR DESCRIPTION
## Description

This PR (among other minor fixes) adds the `org.projectcalico.profile` option to the docker driver, that associates the created network with a calico profile. Without this, `libnetwork-plugin` assumes that the profile name is the same as the ip-pool name.

You should now create the network on docker like so:

```sh
docker network create \
    --opt org.projectcalico.profile=calico \
    --driver calico \
    --ipam-driver calico-ipam \
    --subnet=192.168.0.0/16 \
    calico
```

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note
